### PR TITLE
Update Default map provider, Mapquest is broken

### DIFF
--- a/dialogs/leaflet.js
+++ b/dialogs/leaflet.js
@@ -248,7 +248,7 @@ CKEDITOR.dialog.add('leaflet', function(editor) {
 
                 else {
                   // Set the default value.
-                  this.setValue('MapQuestOpen.OSM');
+                  this.setValue('OpenStreetMap.Mapnik');
                 }
               },
 


### PR DESCRIPTION
I'm not sure what should be done about maps that are already created, but as for creating new maps, switching the default provider to OpenStreetMaps will remedy the problem of the default option not working.

Issue #11 