### PR TITLE
Fixing incorrect handling of non-Latin characters in Pop-up balloon

### DIFF
--- a/scripts/mapParser.html
+++ b/scripts/mapParser.html
@@ -103,7 +103,7 @@
       }
 
       // Retrive the popup text that will be used by the marker.
-      var popUpText = queryString["text"];
+      var popUpText = decodeURIComponent(queryString["text"]);
 
       // Retrieve the Base Map's Tile to be used.
       var tile = queryString["tile"];


### PR DESCRIPTION
I've noticed a bug with incorrect encoding when I entered Russian (Cyrillic) text in the "Pop-up Text". Here is a quick fix
![2016-08-16 12_24_43-test page of ckeditor leaflet maps](https://cloud.githubusercontent.com/assets/2891792/17694727/eed73b78-63ad-11e6-9201-39b0019a2f3c.png)
